### PR TITLE
feat: message formatting + inline keyboard helpers

### DIFF
--- a/src/MessageFormat.res
+++ b/src/MessageFormat.res
@@ -1,0 +1,184 @@
+// Message format types using polymorphic variants
+type format = [#Regular | #Markdown | #HTML]
+
+// Button action types using polymorphic variants
+type buttonAction = [
+  | #Callback(string)
+  | #Url(string)
+  | #SwitchInlineQuery(string)
+  | #SwitchInlineQueryCurrentChat(string)
+]
+
+// Type for inline keyboard buttons
+type rec button = {
+  text: string,
+  action: buttonAction,
+}
+
+// Type for reply markup
+and markup =
+  | InlineKeyboard(array<array<button>>)
+  | ReplyKeyboard({
+      buttons: array<array<string>>,
+      resize: bool,
+      oneTime: bool,
+      placeholder: option<string>,
+    })
+  | RemoveKeyboard
+  | ForceReply({placeholder: option<string>, selective: bool})
+
+// Type for message options
+and options = {
+  format: format,
+  disableWebPagePreview: bool,
+  disableNotification: bool,
+  replyMarkup: option<markup>,
+}
+
+// Create default message options
+let defaultOptions = {
+  format: #Regular,
+  disableWebPagePreview: false,
+  disableNotification: false,
+  replyMarkup: None,
+}
+
+// Helper functions for buttons
+let button = (~text, ~url) => {
+  text,
+  action: #Url(url),
+}
+
+let callbackButton = (~text, ~data) => {
+  text,
+  action: #Callback(data),
+}
+
+let switchInlineButton = (~text, ~query, ~currentChat=false) => {
+  text,
+  action: currentChat ? #SwitchInlineQueryCurrentChat(query) : #SwitchInlineQuery(query),
+}
+
+// Helper functions for markup
+let inlineKeyboard = buttons => InlineKeyboard(buttons)
+
+let replyKeyboard = (~buttons, ~resize=true, ~oneTime=false, ~placeholder=?) =>
+  ReplyKeyboard({
+    buttons,
+    resize,
+    oneTime,
+    placeholder,
+  })
+
+// Convert options to Telegram API format
+let toTelegramOptions = (options): Bindings.Telegraf.MessageOptions.t => {
+  // Create parseMode based on format
+  let parseMode = switch options.format {
+  | #Markdown => Some("MarkdownV2")
+  | #HTML => Some("HTML")
+  | #Regular => None
+  }
+
+  // Convert replyMarkup to Telegraf format
+  let replyMarkup = switch options.replyMarkup {
+  | Some(InlineKeyboard(buttons)) => {
+      // Convert our buttons to Telegraf's InlineKeyboardButton format
+      let inlineKeyboard =
+        Array.map(buttons, row =>
+          Array.map(row, button => {
+            // Create a proper InlineKeyboardButton object matching the binding's type
+            let buttonObj: Bindings.Telegraf.InlineKeyboardButton.t = switch button.action {
+            | #Callback(data) => {
+                text: button.text,
+                callbackData: Some(data),
+                url: None
+              }
+            | #Url(url) => {
+                text: button.text,
+                url: Some(url),
+                callbackData: None
+              }
+            | #SwitchInlineQuery(query) => {
+                text: button.text,
+                callbackData: Some(`switch:${query}`),
+                url: None
+              }
+            | #SwitchInlineQueryCurrentChat(query) => {
+                text: button.text,
+                callbackData: Some(`switchCurrent:${query}`),
+                url: None
+              }
+            }
+            buttonObj
+          })
+        )
+
+      // Create the ReplyMarkup object with inlineKeyboard
+      let markup: Bindings.Telegraf.ReplyMarkup.t = {
+        inlineKeyboard: inlineKeyboard
+      }
+      markup
+    }
+  | Some(ReplyKeyboard(_)) | Some(RemoveKeyboard) | Some(ForceReply(_)) | None => {
+      // For unsupported markup types, create an empty inline keyboard
+      let markup: Bindings.Telegraf.ReplyMarkup.t = {
+        inlineKeyboard: []
+      }
+      markup
+    }
+  }
+
+  // Construct and return the properly typed MessageOptions object
+  {
+    replyMarkup: replyMarkup,
+    parseMode: parseMode
+  }
+}
+
+// Markdown helpers
+let escapeMarkdown = text => {
+  // Characters that need escaping in MarkdownV2: _ * [ ] ( ) ~ ` > # + - = | { } . !
+  let specialChars = [
+    "_",
+    "*",
+    "[",
+    "]",
+    "(",
+    ")",
+    "~",
+    "`",
+    ">",
+    "#",
+    "+",
+    "-",
+    "=",
+    "|",
+    "{",
+    "}",
+    ".",
+    "!",
+  ]
+
+  let textEscaped = Array.reduce(specialChars, text, (acc, char) => {
+    let pattern = switch char {
+    | "[" | "]" | "(" | ")" | "{" | "}" | "." | "+" | "*" | "|" | "^" | "$" | "?" | "\\" =>
+      "\\" ++ char
+    | _ => char
+    }
+    let regex = RegExp.fromString(pattern, ~flags="g")
+    acc->String.replaceRegExp(regex, "\\" ++ char)
+  })
+  textEscaped
+}
+
+// Markdown formatting helpers
+let bold = text => "*" ++ text->escapeMarkdown ++ "*"
+let italic = text => "_" ++ text->escapeMarkdown ++ "_"
+let code = text => "`" ++ text->escapeMarkdown ++ "`"
+let pre = (text, ~language=?) => {
+  let lang = language->Option.getOr("")
+  "```" ++ lang ++ "\n" ++ text->escapeMarkdown ++ "\n```"
+}
+let link = (text, url) => "[" ++ text->escapeMarkdown ++ "](" ++ url->escapeMarkdown ++ ")"
+let mention = (text, userId) =>
+  "[" ++ text->escapeMarkdown ++ "](tg://user?id=" ++ Int.toString(userId) ++ ")"


### PR DESCRIPTION
### TL;DR

Added a new MessageFormat module to handle Telegram message formatting and keyboard options.

### What changed?

Created a new `MessageFormat.res` file that provides:

- Type definitions for message formats (`Regular`, `Markdown`, `HTML`)
- Button action types and helper functions for creating buttons
- Keyboard markup options (inline keyboards, reply keyboards)
- Conversion functions to transform our custom types to Telegram API format
- Markdown escaping and formatting utilities (bold, italic, code, pre, link, mention)

The module provides a clean, type-safe interface for formatting messages and creating interactive elements like buttons and keyboards in Telegram bots.

### How to test?

1. Import the module in a bot handler:
   ```rescript
   open MessageFormat
   ```

2. Test message formatting:
   ```rescript
   let formattedMessage = bold("Important") ++ ": " ++ italic("This is a test")
   ```

3. Test creating buttons and keyboards:
   ```rescript
   let keyboard = inlineKeyboard([
     [button(~text="Visit Website", ~url="https://example.com")],
     [callbackButton(~text="Click Me", ~data="button_clicked")]
   ])
   
   let options = {...defaultOptions, format: #Markdown, replyMarkup: Some(keyboard)}
   ```

4. Send a message using the formatted options:
   ```rescript
   ctx->Ctx.reply(formattedMessage, toTelegramOptions(options))
   ```

### Why make this change?

This module provides a more ergonomic and type-safe way to work with Telegram's message formatting and interactive elements. It abstracts away the complexity of the Telegram API format, making it easier to create rich, interactive messages with proper formatting. The polymorphic variants and helper functions ensure type safety while providing a clean, intuitive API for bot developers.